### PR TITLE
Support http requests for services like tos.ea.com

### DIFF
--- a/src/main/java/com/ea/ServerApp.java
+++ b/src/main/java/com/ea/ServerApp.java
@@ -5,6 +5,7 @@ import com.ea.config.SslSocketThread;
 import com.ea.config.TcpSocketThread;
 import com.ea.config.UdpSocketThread;
 import com.ea.dto.SessionData;
+import com.ea.enums.CertificateKind;
 import com.ea.utils.Props;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -12,13 +13,16 @@ import org.springframework.boot.CommandLineRunner;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
+import org.springframework.core.env.Environment;
 
 import javax.net.ssl.SSLServerSocket;
 import javax.net.ssl.SSLSocket;
 import java.io.IOException;
 import java.net.DatagramSocket;
 import java.net.ServerSocket;
+import java.net.Socket;
 import java.security.Security;
+import java.util.function.BiFunction;
 
 /**
  * Entry point
@@ -26,11 +30,17 @@ import java.security.Security;
 @Slf4j
 @SpringBootApplication(exclude = { SecurityAutoConfiguration.class })
 public class ServerApp implements CommandLineRunner {
-    @Autowired
-    Props props;
+
+    private static final String WII = "wii";
 
     @Autowired
-    ServerConfig serverConfig;
+    private Props props;
+
+    @Autowired
+    private Environment env;
+
+    @Autowired
+    private ServerConfig serverConfig;
 
     public static void main(String[] args) {
         SpringApplication.run(ServerApp.class, args);
@@ -50,36 +60,42 @@ public class ServerApp implements CommandLineRunner {
 
         try {
             log.info("Starting servers...");
-            SSLServerSocket sslServerSocket = serverConfig.createSslServerSocket();
-            ServerSocket tcpServerSocket = serverConfig.createTcpServerSocket();
+
+            CertificateKind certificateKind = env.getActiveProfiles().length > 0
+                   && env.getActiveProfiles()[0].contains(WII) ? CertificateKind.MOH_WII : CertificateKind.MOH_PSP;
+
+            SSLServerSocket sslServerSocket = serverConfig.createSslServerSocket(props.getSslPort(), certificateKind);
+            SSLServerSocket sslTosServerSocket = serverConfig.createSslServerSocket(443, CertificateKind.TOS);
+            ServerSocket tcpServerSocket = serverConfig.createTcpServerSocket(props.getTcpPort());
+            ServerSocket tcpTosServerSocket = serverConfig.createTcpServerSocket(80);
+
             if(!props.isConnectModeEnabled()) {
                 DatagramSocket udpServerSocket = serverConfig.createUdpServerSocket();
                 new Thread(new UdpSocketThread(udpServerSocket)).start();
             }
 
-            new Thread(() -> {
-                try {
-                    while (true) {
-                        new Thread(new SslSocketThread((SSLSocket) sslServerSocket.accept())).start();
-                    }
-                } catch (IOException e) {
-                    log.error("Error accepting SSL connections", e);
-                }
-            }).start();
-
-            new Thread(() -> {
-                try {
-                    while (true) {
-                        new Thread(new TcpSocketThread(tcpServerSocket.accept(), new SessionData())).start();
-                    }
-                } catch (IOException e) {
-                    log.error("Error accepting TCP connections", e);
-                }
-            }).start();
+            startServerThread(sslServerSocket, (socket, sessionData) -> new SslSocketThread((SSLSocket) socket));
+            startServerThread(sslTosServerSocket, (socket, sessionData) -> new SslSocketThread((SSLSocket) socket));
+            startServerThread(tcpServerSocket, TcpSocketThread::new);
+            startServerThread(tcpTosServerSocket, TcpSocketThread::new);
 
             log.info("Servers started. Waiting for client connections...");
         } catch (Exception e) {
             log.error("Error starting servers", e);
         }
     }
+
+    private void startServerThread(ServerSocket serverSocket, BiFunction<Socket, SessionData, Runnable> runnableFactory) {
+        new Thread(() -> {
+            try {
+                while (true) {
+                    Socket socket = serverSocket.accept();
+                    new Thread(runnableFactory.apply(socket, new SessionData())).start();
+                }
+            } catch (IOException e) {
+                log.error("Error accepting connections", e);
+            }
+        }).start();
+    }
+
 }

--- a/src/main/java/com/ea/config/ServerConfig.java
+++ b/src/main/java/com/ea/config/ServerConfig.java
@@ -1,5 +1,6 @@
 package com.ea.config;
 
+import com.ea.enums.CertificateKind;
 import com.ea.utils.Props;
 import com.ea.dirtysdk.ProtoSSL;
 import lombok.RequiredArgsConstructor;
@@ -31,12 +32,12 @@ public class ServerConfig {
      * @return SSLServerSocket
      * @throws IOException
      */
-    public SSLServerSocket createSslServerSocket() throws Exception {
-        Pair<KeyPair, Certificate> eaCert = protoSSL.getEaCert();
+    public SSLServerSocket createSslServerSocket(int port, CertificateKind certificateKind) throws Exception {
+        Pair<KeyPair, Certificate> eaCert = protoSSL.getEaCert(certificateKind);
 
         KeyStore keyStore = KeyStore.getInstance(KeyStore.getDefaultType());
         keyStore.load(null, null);
-        keyStore.setKeyEntry("wiimoh08.ea.com", eaCert.getLeft().getPrivate(), "password".toCharArray(), new Certificate[]{eaCert.getRight()});
+        keyStore.setKeyEntry(certificateKind.getName(), eaCert.getLeft().getPrivate(), "password".toCharArray(), new Certificate[]{eaCert.getRight()});
 
         KeyManagerFactory keyManagerFactory = KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm());
         keyManagerFactory.init(keyStore, "password".toCharArray());
@@ -45,7 +46,7 @@ public class ServerConfig {
         sslContext.init(keyManagerFactory.getKeyManagers(), null, null);
 
         SSLServerSocketFactory sslServerSocketFactory = sslContext.getServerSocketFactory();
-        SSLServerSocket sslServerSocket = (SSLServerSocket) sslServerSocketFactory.createServerSocket(props.getSslPort());
+        SSLServerSocket sslServerSocket = (SSLServerSocket) sslServerSocketFactory.createServerSocket(port);
 
         sslServerSocket.setEnabledProtocols(props.getSslProtocols().split(","));
         sslServerSocket.setEnabledCipherSuites(props.getSslCipherSuites().split(","));
@@ -58,8 +59,8 @@ public class ServerConfig {
      * @return ServerSocket
      * @throws IOException
      */
-    public ServerSocket createTcpServerSocket() throws IOException {
-        return ServerSocketFactory.getDefault().createServerSocket(props.getTcpPort());
+    public ServerSocket createTcpServerSocket(int port) throws IOException {
+        return ServerSocketFactory.getDefault().createServerSocket(port);
     }
 
     /**

--- a/src/main/java/com/ea/config/SslSocketThread.java
+++ b/src/main/java/com/ea/config/SslSocketThread.java
@@ -25,8 +25,6 @@ public class SslSocketThread implements Runnable {
         try {
             SocketReader socketReader = new SocketReader();
             socketReader.read(clientSocket, null);
-        } catch (IOException e) {
-            log.error("Error reading from socket", e);
         } finally {
             log.info("SSL client session ended: {}:{}", clientSocket.getInetAddress().getHostAddress(), clientSocket.getPort());
         }

--- a/src/main/java/com/ea/config/TcpSocketThread.java
+++ b/src/main/java/com/ea/config/TcpSocketThread.java
@@ -43,8 +43,6 @@ public class TcpSocketThread implements Runnable {
             pingExecutor.scheduleAtFixedRate(() -> png(clientSocket), 30, 30, TimeUnit.SECONDS);
 
             SocketReader.read(clientSocket, sessionData);
-        } catch (IOException e) {
-            log.error("Error reading from socket", e);
         } finally {
             pingExecutor.shutdown();
             lobbyService.endLobbyReport(sessionData); // If the player doesn't leave from the game

--- a/src/main/java/com/ea/dirtysdk/ProtoSSL.java
+++ b/src/main/java/com/ea/dirtysdk/ProtoSSL.java
@@ -1,5 +1,6 @@
 package com.ea.dirtysdk;
 
+import com.ea.enums.CertificateKind;
 import com.ea.utils.Props;
 import lombok.RequiredArgsConstructor;
 import org.apache.commons.lang3.tuple.Pair;
@@ -47,20 +48,21 @@ public class ProtoSSL {
 
     private final ConcurrentHashMap<String, Pair<KeyPair, Certificate>> certCache = new ConcurrentHashMap<>();
 
-    public Pair<KeyPair, Certificate> getEaCert() throws Exception {
-        String cacheKey = "cert_ea";
+    public Pair<KeyPair, Certificate> getEaCert(CertificateKind certificateKind) throws Exception {
+        String cacheKey = certificateKind.getName();
         if (certCache.containsKey(cacheKey)) {
             return certCache.get(cacheKey);
         }
 
-        Pair<KeyPair, Certificate> creds = generateVulnerableCert();
+        Pair<KeyPair, Certificate> creds = generateVulnerableCert(certificateKind);
         certCache.put(cacheKey, creds);
+
         return creds;
     }
 
-    private Pair<KeyPair, Certificate> generateVulnerableCert() throws Exception {
+    private Pair<KeyPair, Certificate> generateVulnerableCert(CertificateKind certificateKind) throws Exception {
         KeyPair cKeyPair = generateKeyPair();
-        Certificate cCertificate = generateCertificate(props.getSslCertificateSubject(), cKeyPair, cKeyPair.getPrivate(), props.getSslCertificateIssuer());
+        Certificate cCertificate = generateCertificate(certificateKind.getSubject(), cKeyPair, cKeyPair.getPrivate(), certificateKind.getIssuer());
         Certificate patchedCCertificate = patchCertificateSignaturePattern(cCertificate);
         return Pair.of(cKeyPair, patchedCCertificate);
     }

--- a/src/main/java/com/ea/dto/HttpRequestData.java
+++ b/src/main/java/com/ea/dto/HttpRequestData.java
@@ -1,0 +1,13 @@
+package com.ea.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class HttpRequestData {
+    private String method;
+    private String uri;
+}

--- a/src/main/java/com/ea/enums/CertificateKind.java
+++ b/src/main/java/com/ea/enums/CertificateKind.java
@@ -1,0 +1,35 @@
+package com.ea.enums;
+
+public enum CertificateKind {
+    MOH_WII("MOH_WII",
+            "CN=wiimoh08.ea.com, OU=Global Online Studio, O=Electronic Arts, Inc., ST=California, C=US",
+            "OU=Online Technology Group, O=Electronic Arts, Inc., L=Redwood City, ST=California, C=US, CN=OTG3 Certificate Authority"),
+    MOH_PSP("MOH_PSP",
+            "CN=pspmoh08.ea.com, OU=Global Online Studio, O=Electronic Arts, Inc., ST=California, C=US",
+            "OU=Online Technology Group, O=Electronic Arts, Inc., L=Redwood City, ST=California, C=US, CN=OTG3 Certificate Authority"),
+    TOS("TOS",
+            "CN=tos.ea.com, OU=Global Online Studio, O=Electronic Arts, Inc., ST=California, C=US",
+            "OU=Online Technology Group, O=Electronic Arts, Inc., L=Redwood City, ST=California, C=US, CN=OTG3 Certificate Authority");
+
+    private final String name;
+    private final String subject;
+    private final String issuer;
+
+    CertificateKind(String name, String subject, String issuer) {
+        this.name = name;
+        this.subject = subject;
+        this.issuer = issuer;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getSubject() {
+        return subject;
+    }
+
+    public String getIssuer() {
+        return issuer;
+    }
+}

--- a/src/main/java/com/ea/steps/HttpProcessor.java
+++ b/src/main/java/com/ea/steps/HttpProcessor.java
@@ -1,0 +1,49 @@
+package com.ea.steps;
+
+import com.ea.dto.HttpRequestData;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.core.io.Resource;
+
+import java.io.IOException;
+import java.net.Socket;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+@Slf4j
+public class HttpProcessor {
+
+    public static void process(Socket socket, HttpRequestData request) {
+        try {
+            if(request.getMethod().equals("GET")
+                    && request.getUri().startsWith("/legalapp")) {
+                log.info("Processing legalapp request");
+                Resource resource = new ClassPathResource("tosa.en.txt");
+                try {
+                    String data = Files.readString(Path.of(resource.getURI()));
+                    String response = "HTTP/1.1 200 OK\r\n" +
+                            "Content-Type: text/html;charset=UTF-8\r\n" +
+                            "\r\n" +
+                            data;
+                    socket.getOutputStream().write(response.getBytes(StandardCharsets.UTF_8));
+                } catch (IOException e) {
+                    String response = "HTTP/1.1 500 Internal Server Error\r\n" +
+                            "Content-Type: text/plain\r\n" +
+                            "\r\n" +
+                            "Server error";
+                    socket.getOutputStream().write(response.getBytes(StandardCharsets.UTF_8));
+                }
+            }
+        } catch (IOException e) {
+            log.error("Error while processing HTTP request", e);
+        } finally {
+            try {
+                socket.close();
+            } catch (IOException e) {
+                log.error("Error while closing socket", e);
+            }
+        }
+    }
+
+}

--- a/src/main/java/com/ea/steps/SocketParser.java
+++ b/src/main/java/com/ea/steps/SocketParser.java
@@ -1,10 +1,9 @@
 package com.ea.steps;
 
+import com.ea.dto.HttpRequestData;
+import com.ea.utils.*;
 import com.ea.dto.SessionData;
 import com.ea.dto.SocketData;
-import com.ea.utils.BeanUtil;
-import com.ea.utils.HexUtils;
-import com.ea.utils.Props;
 import lombok.extern.slf4j.Slf4j;
 
 import java.net.Socket;
@@ -12,6 +11,7 @@ import java.util.Arrays;
 
 @Slf4j
 public class SocketParser {
+
     private static Props props = BeanUtil.getBean(Props.class);
 
     /**
@@ -23,45 +23,36 @@ public class SocketParser {
      * @param readLength the size of written content in buffer
      */
     public static void parse(Socket socket, SessionData sessionData, byte[] buffer, int readLength) {
-        boolean loop = true;
-        int readRemaining = Integer.valueOf(readLength);
-        int lastPos = 0;
+        if (HttpRequestUtils.isHttpPacket(buffer)) {
+            HttpRequestData request = HttpRequestUtils.extractHttpRequest(buffer);
+            HttpProcessor.process(socket, request);
+        } else {
+            boolean loop = true;
+            int readRemaining = Integer.valueOf(readLength);
+            int lastPos = 0;
 
-        while (readRemaining > 11 && loop) {
-            int currentMessageBegin = readLength - readRemaining;
-            int currentMessageLength = getlength(buffer, lastPos);
-            if (readRemaining >= currentMessageLength) {
-                String id = new String(buffer, currentMessageBegin, 4);
-                String content = new String(Arrays.copyOfRange(buffer, currentMessageBegin + 12, currentMessageBegin + currentMessageLength));
-                SocketData socketData = new SocketData(id, content, null);
+            while (readRemaining > 11 && loop) {
+                int currentMessageBegin = readLength - readRemaining;
+                int currentMessageLength = SocketUtils.getlength(buffer, lastPos);
+                if (readRemaining >= currentMessageLength) {
+                    String id = new String(buffer, currentMessageBegin, 4);
+                    String content = new String(Arrays.copyOfRange(buffer, currentMessageBegin + 12, currentMessageBegin + currentMessageLength));
+                    SocketData socketData = new SocketData(id, content, null);
 
-                if (props.isTcpDebugEnabled() && !props.getTcpDebugExclusions().contains(socketData.getIdMessage())) {
-                    byte[] dump = Arrays.copyOfRange(buffer, currentMessageBegin, currentMessageBegin + currentMessageLength);
-                    log.info("Received from {}:{} :\n{}", socket.getInetAddress().getHostAddress(), socket.getPort(), HexUtils.formatHexDump(dump));
+                    if (props.isTcpDebugEnabled() && !props.getTcpDebugExclusions().contains(socketData.getIdMessage())) {
+                        byte[] dump = Arrays.copyOfRange(buffer, currentMessageBegin, currentMessageBegin + currentMessageLength);
+                        log.info("Received from {}:{} :\n{}", socket.getInetAddress().getHostAddress(), socket.getPort(), HexUtils.formatHexDump(dump));
+                    }
+
+                    SocketProcessor.process(socket, sessionData, socketData);
+                    readRemaining -= currentMessageLength;
+                    lastPos += currentMessageLength;
+                } else {
+                    log.info("Cannot parse data");
+                    loop = false;
                 }
-
-                SocketProcessor.process(socket, sessionData, socketData);
-                readRemaining -= currentMessageLength;
-                lastPos += currentMessageLength;
-            } else {
-                log.info("Cannot parse data");
-                loop = false;
             }
         }
-    }
-
-    /**
-     * Calculate length of the content to parse
-     * @param buffer the request buffer (only efficient way to get the length)
-     * @param lastPos the position to begin in the buffer (there can be multiple messages in a buffer)
-     * @return int - the size of the content
-     */
-    private static int getlength(byte[] buffer, int lastPos) {
-        String size = "";
-        for (int i = lastPos + 8; i < lastPos + 12; i++) {
-            size += String.format("%02x", buffer[i]);
-        }
-        return Integer.parseInt(size, 16);
     }
 
 }

--- a/src/main/java/com/ea/steps/SocketReader.java
+++ b/src/main/java/com/ea/steps/SocketReader.java
@@ -6,7 +6,7 @@ import lombok.extern.slf4j.Slf4j;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.Socket;
-import java.util.Optional;
+import java.net.SocketException;
 
 @Slf4j
 public class SocketReader {
@@ -17,12 +17,18 @@ public class SocketReader {
      * @param socket the socket to read
      * @throws IOException
      */
-    public static void read(Socket socket, SessionData sessionData) throws IOException {
-        InputStream is = socket.getInputStream();
-        byte[] buffer = new byte[1024];
-        int readLength;
-        while((readLength = is.read(buffer)) != -1) {
-            SocketParser.parse(socket, sessionData, buffer, readLength);
+    public static void read(Socket socket, SessionData sessionData) {
+        try {
+            InputStream is = socket.getInputStream();
+            byte[] buffer = new byte[1024];
+            int readLength;
+            while((readLength = is.read(buffer)) != -1) {
+                SocketParser.parse(socket, sessionData, buffer, readLength);
+            }
+        } catch (SocketException e) {
+            log.warn("Socket closed, stopping reading");
+        } catch (IOException e) {
+            log.error("Error reading from socket", e);
         }
     }
 

--- a/src/main/java/com/ea/utils/HttpRequestUtils.java
+++ b/src/main/java/com/ea/utils/HttpRequestUtils.java
@@ -1,0 +1,36 @@
+package com.ea.utils;
+
+import com.ea.dto.HttpRequestData;
+
+public class HttpRequestUtils {
+
+
+    /**
+     * Check if the packet is an HTTP packet
+     * @param buffer the request buffer
+     * @return boolean - true if the packet is an HTTP packet
+     */
+    public static boolean isHttpPacket(byte[] buffer) {
+        String packetStart = new String(buffer, 0, Math.min(buffer.length, 10)).toUpperCase();
+        return packetStart.startsWith("GET ") || packetStart.startsWith("POST ")
+                || packetStart.startsWith("PUT ") || packetStart.startsWith("DELETE ")
+                || packetStart.startsWith("HEAD ") || packetStart.startsWith("OPTIONS ")
+                || packetStart.startsWith("PATCH ") || packetStart.startsWith("CONNECT ");
+    }
+
+    /**
+     * Extracts the HTTP request from the buffer
+     * @param buffer the buffer to extract from
+     * @return the extracted HTTP request
+     */
+    public static HttpRequestData extractHttpRequest(byte[] buffer) {
+        String requestLine = new String(buffer).split("\n")[0];
+        String[] parts = requestLine.split(" ");
+
+        HttpRequestData request = new HttpRequestData();
+        request.setMethod(parts[0]);
+        request.setUri(parts[1]);
+
+        return request;
+    }
+}

--- a/src/main/java/com/ea/utils/Props.java
+++ b/src/main/java/com/ea/utils/Props.java
@@ -22,12 +22,6 @@ public class Props {
     @Value("${ssl.certificate.cipher-algorithm}")
     private String sslCertificateCipherAlgorithm;
 
-    @Value("${ssl.certificate.issuer}")
-    private String sslCertificateIssuer;
-
-    @Value("${ssl.certificate.subject}")
-    private String sslCertificateSubject;
-
     @Value("${ssl.debug.enabled}")
     private boolean sslDebugEnabled;
 

--- a/src/main/java/com/ea/utils/SocketUtils.java
+++ b/src/main/java/com/ea/utils/SocketUtils.java
@@ -10,6 +10,30 @@ import java.util.zip.CRC32;
 @Slf4j
 public class SocketUtils {
 
+    /**
+     * Calculate length of the content to parse
+     * @param buffer the request buffer (only efficient way to get the length)
+     * @param lastPos the position to begin in the buffer (there can be multiple messages in a buffer)
+     * @return int - the size of the content
+     */
+    public static int getlength(byte[] buffer, int lastPos) {
+        String size = "";
+        for (int i = lastPos + 8; i < lastPos + 12; i++) {
+            size += String.format("%02x", buffer[i]);
+        }
+        return Integer.parseInt(size, 16);
+    }
+
+    /**
+     * Get the value from a key in a socket data
+     * E.g. : data = "key1=value1\nkey2=value
+     * getValueFromSocket(data, "key1") returns "value1"
+     * getValueFromSocket(data, "key2") returns "value2"
+     *
+     * @param data
+     * @param key
+     * @return
+     */
     public static String getValueFromSocket(String data, String key) {
         String result = null;
         String[] entries = data.split("\\R");

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,13 +1,8 @@
-server:
-  port: 8080
-
 ssl:
   protocols: 'SSLv3'
   cipher-suites: 'SSL_RSA_WITH_RC4_128_MD5,SSL_RSA_WITH_RC4_128_SHA'
   certificate:
     cipher-algorithm: 'MD5WITHRSA'
-    issuer: 'OU=Online Technology Group, O=Electronic Arts, Inc., L=Redwood City, ST=California, C=US, CN=OTG3 Certificate Authority'
-    subject: 'CN=wiimoh08.ea.com, OU=Global Online Studio, O=Electronic Arts, Inc., ST=California, C=US'
   debug:
     enabled: ${SSL_DEBUG_ENABLED:false}
 tcp:
@@ -77,8 +72,6 @@ spring:
 
 ssl:
   port: 21181
-  certificate:
-    subject: 'CN=pspmoh08.ea.com, OU=Global Online Studio, O=Electronic Arts, Inc., ST=California, C=US'
 tcp:
   port: 21182
 udp:
@@ -92,8 +85,6 @@ spring:
 
 ssl:
   port: 21191
-  certificate:
-    subject: 'CN=pspmoh08.ea.com, OU=Global Online Studio, O=Electronic Arts, Inc., ST=California, C=US'
 tcp:
   port: 21192
 udp:

--- a/src/main/resources/tosa.en.txt
+++ b/src/main/resources/tosa.en.txt
@@ -1,0 +1,7 @@
+﻿ %{START CMD=news TITLE="Welcome" BTN1="OK" BTN1-GOTO="$quit" TELE=TOSVVIEWen %}
+Official servers were shut down on August 11, 2011.
+
+This is a community run server, please be respectful and have fun !
+
+- l ch ti, SolidSnakeRu, and everyone making it possible <3
+%{%}


### PR DESCRIPTION
- Fixes #23
- Add sockets to handle both http and https requests
- Mock response of `tos.ea.com/legalapp/**`
- Improve certificate management (use Enum instead of properties)